### PR TITLE
Persisting redux state globally

### DIFF
--- a/PSK.UII/ClientApp/package-lock.json
+++ b/PSK.UII/ClientApp/package-lock.json
@@ -10801,6 +10801,11 @@
         "symbol-observable": "^1.2.0"
       }
     },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
+    },
     "redux-thunk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",

--- a/PSK.UII/ClientApp/package.json
+++ b/PSK.UII/ClientApp/package.json
@@ -16,6 +16,7 @@
     "react-scripts": "^3.0.1",
     "reactstrap": "^6.3.0",
     "redux": "^4.0.5",
+    "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
     "rimraf": "^2.6.2",
     "universal-cookie": "^4.0.3"

--- a/PSK.UII/ClientApp/src/App.js
+++ b/PSK.UII/ClientApp/src/App.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react'
 import Routes from './routes/Routes';
-import store from './redux/store';
+import getStore from './redux/store';
+
+const { store, persistor } = getStore();
 
 const App = () => (
   <Provider store={store}>
-    <Routes/>
+    <PersistGate loading={null} persistor={persistor}>
+      <Routes/>
+    </PersistGate>
   </Provider>
 );
 

--- a/PSK.UII/ClientApp/src/redux/store.js
+++ b/PSK.UII/ClientApp/src/redux/store.js
@@ -1,11 +1,22 @@
 import { compose, applyMiddleware, createStore } from 'redux';
 import rootReducer from './reducers/rootReducer';
 import thunk from 'redux-thunk';
+import { persistStore, persistReducer } from 'redux-persist'
+import storage from 'redux-persist/lib/storage'
 
-const store = createStore(
-    rootReducer,
-    {},
-    compose(applyMiddleware(thunk))
-)
+const persistConfig = {
+    key: 'root',
+    storage,
+}
 
-export default store;
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+export default () => {
+    let store = createStore(
+        persistedReducer,
+        {},
+        compose(applyMiddleware(thunk))
+    );
+    let persistor = persistStore(store);
+    return { store, persistor };
+}

--- a/PSK.UII/ClientApp/src/routes/Routes.js
+++ b/PSK.UII/ClientApp/src/routes/Routes.js
@@ -47,16 +47,11 @@ class Routes extends React.Component{
     render(){
         const { currentUser } = this.props;
 
-        /* Do not show login page when logging-in with token */
-        if (!currentUser.token && getCookie('AuthToken'))
-            return <div/>;
-
         if (!currentUser || !currentUser.token)
             return (
                 <BrowserRouter basename={'MegstuKumpi'}>
                     <Switch>
                         <Route path='/' exact component={LoginPage} />
-                        <Route path='/invite' component={InvitePage} />
                         <Route component={NotFoundPage}/>
                     </Switch>
                 </BrowserRouter>


### PR DESCRIPTION
Laikys redux state po refresh. Routes.js panaikintas patikrinimas, jog jeigu yra tokenas bet redux dar nėra currentUser, kad grąžintų tuščią div'ą. Tas buvo padaryta, nes komponentas spėdavo užsimountint kol pareidavo token'o check request'as, ir trumpam rodydavo login'o langą. Dabar to nereikia, nes pats PersistGate turi atributą loading (dabar palikau null, vėliau galėsim kokį loaderį įdėt), kuris yra rodomas kol grąžinamas state iš localStorage